### PR TITLE
Fix the owner label

### DIFF
--- a/test_data/ingress.json
+++ b/test_data/ingress.json
@@ -11,7 +11,7 @@
       "name": "tls-example-ingress",
       "labels": {
         "cc-center": "123",
-        "owner": "some-owner"
+        "owner": "team-alpha"
       }
     },
     "spec": {


### PR DESCRIPTION
The sample ingress has `owner: some-owner` but it'll be rejected by the tests in the tutorial unexpectedly. e.g.: https://docs.kubewarden.io/writing-policies/go/04-validation.html

```
func TestAcceptRequestWithConstraintLabel(t *testing.T) {
    constrainedLabels := make(map[string]*RegularExpression)
    re, err := CompileRegularExpression(`^team-`)
    (snip)
    constrainedLabels["owner"] = re
```