### PR TITLE
Update e2e tests to work with `kwctl`

### DIFF
--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WASM_BINARY_NAME: policy.wasm
-      KWCTL_VERSION: v0.1.9
+      KWCTL_VERSION: v0.1.10
       TINYGO_VERSION: 0.18.0
     steps:
       #############################
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OCI_TARGET: #TODO: change to something like ghcr.io/kubewarden/policies/safe-labels
-      KWCTL_VERSION: v0.1.9
+      KWCTL_VERSION: v0.1.10
 
     steps:
       - name: Download artifact

--- a/e2e.bats
+++ b/e2e.bats
@@ -1,39 +1,33 @@
 #!/usr/bin/env bats
 
 @test "reject because name is on deny list" {
-  run policy-testdrive -p policy.wasm -r test_data/ingress.json -s '{"denied_names": ["foo", "tls-example-ingress"]}'
+  run kwctl run policy.wasm -r test_data/ingress.json --settings-json '{"denied_names": ["foo", "tls-example-ingress"]}'
 
   # this prints the output when one the checks below fails
   echo "output = ${output}"
 
-  # settings validation passed
-  [[ "$output" == *"valid: true"* ]]
-
   # request rejected
-  [[ "$output" == *"allowed: false"* ]]
-  [[ "$output" == *"The \'tls-example-ingress\' name is on the deny list"* ]]
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*allowed.*false') -ne 0 ]
+  [ $(expr "$output" : ".*The 'tls-example-ingress' name is on the deny list.*") -ne 0 ]
 }
 
 @test "accept because name is not on the deny list" {
-  run policy-testdrive -p policy.wasm -r test_data/ingress.json -s '{"denied_names": ["foo"]}'
+  run kwctl run policy.wasm -r test_data/ingress.json --settings-json '{"denied_names": ["foo"]}'
   # this prints the output when one the checks below fails
   echo "output = ${output}"
 
-  # settings validation passed
-  [[ "$output" == *"valid: true"* ]]
-
   # request accepted
-  [[ "$output" == *"allowed: true"* ]]
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*allowed.*true') -ne 0 ]
 }
 
 @test "accept because the deny list is empty" {
-  run policy-testdrive -p policy.wasm -r test_data/ingress.json
+  run kwctl run policy.wasm -r test_data/ingress.json
   # this prints the output when one the checks below fails
   echo "output = ${output}"
 
-  # settings validation passed
-  [[ "$output" == *"valid: true"* ]]
-
   # request accepted
-  [[ "$output" == *"allowed: true"* ]]
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*allowed.*true') -ne 0 ]
 }


### PR DESCRIPTION
No change neded to Github Actions for `kwctl`.
Bump `KWCTL_VERSION` to `v0.1.10` in GA now that we are at it.