### PR TITLE
Return error in the Valid() method.

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -56,8 +56,8 @@ func newSettings(payload []byte, paths ...string) (Settings, error) {
 }
 
 // No special check has to be done
-func (s *Settings) Valid() bool {
-	return true
+func (s *Settings) Valid() (bool, error) {
+	return true, nil
 }
 
 func validateSettings(payload []byte) ([]byte, error) {
@@ -68,7 +68,7 @@ func validateSettings(payload []byte) ([]byte, error) {
 		return kubewarden.RejectSettings(kubewarden.Message(err.Error()))
 	}
 
-	if settings.Valid() {
+	if valid, _ := settings.Valid(); valid {
 		return kubewarden.AcceptSettings()
 	}
 

--- a/settings.go
+++ b/settings.go
@@ -68,7 +68,11 @@ func validateSettings(payload []byte) ([]byte, error) {
 		return kubewarden.RejectSettings(kubewarden.Message(err.Error()))
 	}
 
-	if valid, _ := settings.Valid(); valid {
+	valid, err := settings.Valid()
+	if err != nil {
+		return kubewarden.RejectSettings(kubewarden.Message(fmt.Sprintf("Provided settings are not valid: %v", err)))
+	}
+	if valid {
 		return kubewarden.AcceptSettings()
 	}
 

--- a/settings_test.go
+++ b/settings_test.go
@@ -60,7 +60,7 @@ func TestSettingsAreValid(t *testing.T) {
 		t.Errorf("Unexpected error %+v", err)
 	}
 
-	if !settings.Valid() {
+	if valid, err := settings.Valid(); !valid && err != nil {
 		t.Errorf("Settings are reported as not valid")
 	}
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -60,7 +60,11 @@ func TestSettingsAreValid(t *testing.T) {
 		t.Errorf("Unexpected error %+v", err)
 	}
 
-	if valid, err := settings.Valid(); !valid && err != nil {
+	valid, err := settings.Valid()
+	if !valid {
 		t.Errorf("Settings are reported as not valid")
+	}
+	if err != nil {
+		t.Errorf("Unexpected error %+v", err)
 	}
 }


### PR DESCRIPTION
Updates the Valid() method in the Settings type. Thus, the caller can get a explanation why the settings are not valid and print a proper error message.