### PR TITLE
Remove input from workflow

### DIFF
--- a/.github/workflows/release.yml.template
+++ b/.github/workflows/release.yml.template
@@ -26,5 +26,3 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@v1
     with:
       oci-target: #FIXME: change to something like ghcr.io/${{ github.repository_owner }}/policies/safe-labels
-    secrets:
-      workflow-pat: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
## Description

As visible here : https://github.com/kubewarden/github-actions/blob/9d230fae75f22d03ee56bc9414722a8fab66428e/.github/workflows/reusable-release-policy-go.yml there is no more workflow-pat input. 

## Fix

This should be removed here too

Signed-off-by: Mathis Joffre <51022808+Joffref@users.noreply.github.com>