### PR TITLE
feat: add `lint` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ test: types_easyjson.go
 e2e-tests: annotated-policy.wasm
 	bats e2e.bats
 
+.PHONY: lint
+lint:
+	go vet ./...
+	golangci-lint run
+
 .PHONY: clean
 clean:
 	go clean


### PR DESCRIPTION
Run linters to ensure the quality of the code is good

Note well: the target assumes the golangci-lint binary is already installed on the machine. I don't think there's a clean way to deal with that...

The GH action will deal with that in a better way, see https://github.com/kubewarden/github-actions/pull/64

