### PR TITLE
chore(deps): update kubewarden go SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/go-openapi/strfmt => github.com/kubewarden/strfmt v0.1.2
 require (
 	github.com/francoispqt/onelog v0.0.0-20190306043706-8c2bb31b10a4
 	github.com/kubewarden/k8s-objects v1.26.0-kw2
-	github.com/kubewarden/policy-sdk-go v0.4.0
+	github.com/kubewarden/policy-sdk-go v0.4.1
 	github.com/mailru/easyjson v0.7.7
 	github.com/wapc/wapc-guest-tinygo v0.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -6,14 +6,10 @@ github.com/francoispqt/onelog v0.0.0-20190306043706-8c2bb31b10a4 h1:N9eG+1y9e3tn
 github.com/francoispqt/onelog v0.0.0-20190306043706-8c2bb31b10a4/go.mod h1:v1Il1fkBpjiYPpEJcGxqgrPUPcHuTC7eHh9zBV3CLBE=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/kubewarden/k8s-objects v1.26.0-kw1 h1:MMnU8HNAJZTRl4Kl7ZrjsvMCnFbXEpUd4ZTtikNyh8c=
-github.com/kubewarden/k8s-objects v1.26.0-kw1/go.mod h1:IuIHLG1JtxjC1JnY7SyEEA9MukCh/FACcwpzaBjgdLQ=
 github.com/kubewarden/k8s-objects v1.26.0-kw2 h1:m0zIlifROK3vAy5zR90qRXdCPWQGJUuqagxHA5Bf+Bo=
 github.com/kubewarden/k8s-objects v1.26.0-kw2/go.mod h1:IuIHLG1JtxjC1JnY7SyEEA9MukCh/FACcwpzaBjgdLQ=
-github.com/kubewarden/policy-sdk-go v0.3.0 h1:5WqhrC3eJP+gRti14d4vCyXCITeM95X4hob6QA96eX8=
-github.com/kubewarden/policy-sdk-go v0.3.0/go.mod h1:zJLxhZkoFVKOlHJ3mlbG8qTCvVbkZprZ7odVwVsunUo=
-github.com/kubewarden/policy-sdk-go v0.4.0 h1:qxYHarQ3fHD90QErZEjXRzErEOXLQVtTYKmtyv0rtMQ=
-github.com/kubewarden/policy-sdk-go v0.4.0/go.mod h1:pY1FrcuGdhnzzN31wNieAimI4+7rYWbtkP+tYGna0Ug=
+github.com/kubewarden/policy-sdk-go v0.4.1 h1:MTGxJaWWH6dZBwCdZ+FYVUclxveGzW3p4kuUJiZw+7M=
+github.com/kubewarden/policy-sdk-go v0.4.1/go.mod h1:pY1FrcuGdhnzzN31wNieAimI4+7rYWbtkP+tYGna0Ug=
 github.com/kubewarden/strfmt v0.1.2 h1:S0YUVkPeyUMikz8QssbMzfd1MC5K8ZqxLI2zfF8euMs=
 github.com/kubewarden/strfmt v0.1.2/go.mod h1:sqLlis8qlm4A4pnZsRyRjNxyH86fiM+7Ee7bO+uJk94=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/vendor/github.com/kubewarden/policy-sdk-go/protocol/types.go
+++ b/vendor/github.com/kubewarden/policy-sdk-go/protocol/types.go
@@ -48,10 +48,10 @@ type KubernetesAdmissionRequest struct {
 	Uid string `json:"uid"`
 
 	// Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
-	Kind GroupVersionKind `json:"groupVersionKind"`
+	Kind GroupVersionKind `json:"kind"`
 
 	// Resource is the fully-qualified resource being requested (for example, v1.pods)
-	Resource GroupVersionResource `json:"groupVersionResource"`
+	Resource GroupVersionResource `json:"resource"`
 
 	// SubResource is the subresource being requested, if any (for example, "status" or "scale")
 	SubResource string `json:"subResource"`

--- a/vendor/github.com/kubewarden/policy-sdk-go/protocol/types_easyjson.go
+++ b/vendor/github.com/kubewarden/policy-sdk-go/protocol/types_easyjson.go
@@ -419,9 +419,9 @@ func easyjson6601e8cdDecodeGithubComKubewardenPolicySdkGoProtocol4(in *jlexer.Le
 		switch key {
 		case "uid":
 			out.Uid = string(in.String())
-		case "groupVersionKind":
+		case "kind":
 			(out.Kind).UnmarshalEasyJSON(in)
-		case "groupVersionResource":
+		case "resource":
 			(out.Resource).UnmarshalEasyJSON(in)
 		case "subResource":
 			out.SubResource = string(in.String())
@@ -467,12 +467,12 @@ func easyjson6601e8cdEncodeGithubComKubewardenPolicySdkGoProtocol4(out *jwriter.
 		out.String(string(in.Uid))
 	}
 	{
-		const prefix string = ",\"groupVersionKind\":"
+		const prefix string = ",\"kind\":"
 		out.RawString(prefix)
 		(in.Kind).MarshalEasyJSON(out)
 	}
 	{
-		const prefix string = ",\"groupVersionResource\":"
+		const prefix string = ",\"resource\":"
 		out.RawString(prefix)
 		(in.Resource).MarshalEasyJSON(out)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/kubewarden/k8s-objects/apimachinery/pkg/api/resource
 github.com/kubewarden/k8s-objects/apimachinery/pkg/apis/meta/v1
 github.com/kubewarden/k8s-objects/apimachinery/pkg/runtime/schema
 github.com/kubewarden/k8s-objects/apimachinery/pkg/util/intstr
-# github.com/kubewarden/policy-sdk-go v0.4.0
+# github.com/kubewarden/policy-sdk-go v0.4.1
 ## explicit; go 1.20
 github.com/kubewarden/policy-sdk-go
 github.com/kubewarden/policy-sdk-go/constants


### PR DESCRIPTION
Use latest patch release to include the fix of https://github.com/kubewarden/policy-sdk-go/pull/53
