### PR TITLE
build: remove artifacthub-pkg.yml dependency when annotating a policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ artifacthub-pkg.yml: metadata.yml go.mod
 	  --metadata-path metadata.yml --version $(VERSION) \
 	  --output artifacthub-pkg.yml
 
-annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
+annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm
 
 .PHONY: generate-easyjson


### PR DESCRIPTION
## Description

Removes `artifacthub-pkg.yml` dependency from `annotated-policy.wasm` target
fixing: #50 

This should be good enough, since in the [release policy workflow](https://github.com/kubewarden/github-actions/blob/main/.github/workflows/reusable-release-policy-go.yml) we [use the check artifacthub composable action](https://github.com/kubewarden/github-actions/blob/main/check-artifacthub/action.yml), so the release workflow will keep working.