### PR TITLE
Update tinygo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ policy.wasm: $(SOURCE_FILES) go.mod go.sum
 		--rm \
 		-e GOFLAGS="-buildvcs=false" \
 		-v ${PWD}:/src \
-		-w /src tinygo/tinygo:0.30.0 \
+		-w /src tinygo/tinygo:0.31.2 \
 		tinygo build -o policy.wasm -target=wasi -no-debug .
 
 artifacthub-pkg.yml: metadata.yml go.mod


### PR DESCRIPTION
## Description
Update to version 0.31.2 to make it compatible with go 1.22

## Additional Information

### Potential improvement

Make this template compatible with running the latest go versions
