### PR TITLE
fix: update golangci-lint installation path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ e2e-tests: annotated-policy.wasm
 
 golangci-lint: $(GOLANGCI_LINT) ## Install a local copy of golang ci-lint.
 $(GOLANGCI_LINT): ## Install golangci-lint.
-	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
+	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)


### PR DESCRIPTION
## Description
Fix golangci-lint v2 installation path in Makefile.
<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #98 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
Code changes:
```
$(GOLANGCI_LINT): ## Install golangci-lint.
    GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
```
Key updates:

Fixed installation path for golangci-lint v2
Ensure correct installation of version 2.1.2
## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:
# Clean old build files
make clean
rm -rf bin/

# Install and run lint
make lint
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
