### PR TITLE
chore(deps): fix golang linter installation URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_DIR := $(abspath $(ROOT_DIR)/bin)
 
 SOURCE_FILES := $(shell find . -type f -name '*.go')
 
-GOLANGCI_LINT_VER := v2.1.2
+GOLANGCI_LINT_VER := v2.1.6
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(BIN_DIR)/$(GOLANGCI_LINT_BIN)
 
@@ -29,7 +29,7 @@ e2e-tests: annotated-policy.wasm
 
 golangci-lint: $(GOLANGCI_LINT) ## Install a local copy of golang ci-lint.
 $(GOLANGCI_LINT): ## Install golangci-lint.
-	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
+	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)


### PR DESCRIPTION
## Description

Fix the URL used to install the golang linter v2.

Spin off https://github.com/kubewarden/go-policy-template/pull/99
