### PR TITLE
Revert go version 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubewarden/go-policy-template
 
 go 1.25
 
-toolchain go1.26.0
+toolchain go1.25.7
 
 require (
 	github.com/francoispqt/onelog v0.0.0-20190306043706-8c2bb31b10a4

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/kubewarden/go-policy-template
 
+// TinyGo does not support Go v1.26. Therefore, let's keep go and toolchain
+// versions to 1.25 to ensure that all tinygo and the standard go command (used
+// in makefile) behavie in the same way
 go 1.25
 
 toolchain go1.25.7

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubewarden/go-policy-template
 
 go 1.25
 
-toolchain go1.26.1
+toolchain go1.26.0
 
 require (
 	github.com/francoispqt/onelog v0.0.0-20190306043706-8c2bb31b10a4


### PR DESCRIPTION
## Description

Revert go version used in the template. Tinygo does not support go 1.26 yet. 

